### PR TITLE
Let the user choose whether point should stay after swapping buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ define some keybindings. For example, i use :
     (global-set-key (kbd "<C-S-left>")   'buf-move-left)
     (global-set-key (kbd "<C-S-right>")  'buf-move-right)
 
+By default the point will switch along with the moving buffer,
+if you want the point to stay (as vim switches) you can set
+`buffer-move-stay-after-swap` to a non-nil value like so:
+
+    (setq buffer-move-stay-after-swap t)
+
 Alternatively, you may let the current window switch back to the previous
 buffer, instead of swapping the buffers of both windows. Set the
 following customization variable to 'move to activate this behavior:

--- a/buffer-move.el
+++ b/buffer-move.el
@@ -91,6 +91,12 @@
   :group 'buffer-move
   :type 'symbol)
 
+(defcustom buffer-move-stay-after-swap nil
+  "If set to non-nil, point will stay in the current window
+  so it will not be moved when swapping buffers. This setting
+  only has effect if `buffer-move-behavior' is set to 'swap."
+  :group 'buffer-move
+  :type 'boolean)
 
 (defun buf-move-to (direction)
   "Helper function to move the current buffer to the window in the given
@@ -115,7 +121,9 @@
       ;; switch other window to this buffer
       (set-window-buffer other-win buf-this-buf)
 
-      (select-window other-win))))
+      (when (or (null buffer-move-stay-after-swap)
+              (eq buffer-move-behavior 'move))
+          (select-window other-win)))))
 
 ;;;###autoload
 (defun buf-move-up ()

--- a/buffer-move.el
+++ b/buffer-move.el
@@ -122,8 +122,8 @@
       (set-window-buffer other-win buf-this-buf)
 
       (when (or (null buffer-move-stay-after-swap)
-              (eq buffer-move-behavior 'move))
-          (select-window other-win)))))
+                (eq buffer-move-behavior 'move))
+        (select-window other-win)))))
 
 ;;;###autoload
 (defun buf-move-up ()


### PR DESCRIPTION
Coming from Vim I wanted to have the same switch behaviour where the cursor/point stays in the window instead of switching along with the buffer, this PR adds that as an optional setting.

Now `buffer-move-stay-after-swap` can be set to a non-nil value in
order to keep the point in the window after the buffer swap, this
setting only comes into play when `buffer-move-behavior` is set
to `'swap`. It defaults to `nil`.
